### PR TITLE
read-only mode fix and reduce error popups

### DIFF
--- a/src/app/components/console-page/console-page.component.html
+++ b/src/app/components/console-page/console-page.component.html
@@ -3,7 +3,12 @@
  Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
 -->
 
-<app-console
-  [readOnly]="readOnly$ | async"
-  [vmId]="vmId$ | async"
-></app-console>
+<!-- wait for readOnly http call to evaluate before initializing app-console -->
+<ng-container *ngIf="{ value: readOnly$ | async } as readOnly">
+  <app-console
+    *ngIf="readOnly.value != null"
+    [readOnly]="readOnly.value"
+    [vmId]="vmId$ | async"
+  >
+  </app-console>
+</ng-container>

--- a/src/app/components/console/console.component.ts
+++ b/src/app/components/console/console.component.ts
@@ -12,7 +12,7 @@ import { VmQuery } from '../../state/vm/vm.query';
   styleUrls: ['./console.component.scss'],
 })
 export class ConsoleComponent {
-  @Input() readOnly = false;
+  @Input() readOnly;
 
   @Input() set vmId(value: string) {
     this._vmId = value;

--- a/src/app/components/wmks/wmks.component.ts
+++ b/src/app/components/wmks/wmks.component.ts
@@ -71,9 +71,11 @@ export class WmksComponent {
       takeWhile(() => !this.isDone)
     );
 
-    this.connectTimerSubscription = connectTimer$.subscribe(() =>
-      this.checkConnected()
-    );
+    this.connectTimerSubscription = connectTimer$.subscribe(() => {
+      if (this.readOnly != null) {
+        this.checkConnected();
+      }
+    });
   }
 
   private checkConnected() {

--- a/src/app/services/error/error.service.ts
+++ b/src/app/services/error/error.service.ts
@@ -6,33 +6,40 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { SystemMessageService } from '../system-message/system-message.service';
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: 'root',
 })
 export class ErrorService implements ErrorHandler {
-
-  constructor(private injector: Injector) { }
+  constructor(private injector: Injector) {}
 
   handleError(err: any) {
     const messageService = this.injector.get(SystemMessageService);
-// Http failure response for (unknown url): 0 Unknown Error
+    // Http failure response for (unknown url): 0 Unknown Error
     if (err instanceof HttpErrorResponse) {
-      const apiError = (<HttpErrorResponse>err.error);
+      const apiError = <HttpErrorResponse>err.error;
       if (apiError.name !== undefined) {
         messageService.displayMessage(apiError.name, apiError.message);
-      } else if (err.message === 'Http failure response for (unknown url): 0 Unknown Error') {
-        messageService.displayMessage('VM API Error', 'The VM Console API could not be reached.');
+      } else if (
+        err.message ===
+        'Http failure response for (unknown url): 0 Unknown Error'
+      ) {
+        messageService.displayMessage(
+          'VM API Error',
+          'The VM Console API could not be reached.'
+        );
       } else {
         messageService.displayMessage(err.statusText, err.message);
       }
     } else if (err.message.startsWith('Uncaught (in promise)')) {
       if (err.rejection.message === 'Network Error') {
-        messageService.displayMessage('Identity Server Error', 'The Identity Server could not be reached for user authentication.');
+        messageService.displayMessage(
+          'Identity Server Error',
+          'The Identity Server could not be reached for user authentication.'
+        );
       } else {
         messageService.displayMessage('Error', err.rejection.message);
       }
     } else {
-      messageService.displayMessage(err.name, err.message);
+      console.log(err);
     }
   }
 }
-


### PR DESCRIPTION
fixes read-only mode

- waits for permissions http call to evaluate before rendering console

reduce displayed error messages

- only pop up a message on an http error (api calls), print to console for random javascript errors that are usually harmless