### PR TITLE
Add delay to Paste for text

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,4 +29,6 @@ COPY default.conf /etc/nginx/conf.d/default.conf
 COPY nginx-basehref.sh /docker-entrypoint.d/90-basehref.sh
 COPY --from=builder /ng-app/dist /usr/share/nginx/html
 
+EXPOSE 8080
+
 ENTRYPOINT ["nginx", "-g", "daemon off;"]

--- a/src/app/components/options-bar/options-bar.component.ts
+++ b/src/app/components/options-bar/options-bar.component.ts
@@ -179,7 +179,6 @@ export class OptionsBarComponent implements OnInit, OnDestroy {
       .sendText('Enter Text to Send')
       .subscribe((enteredText: any) => {
         if (enteredText.textToSend) {
-          console.log(enteredText);
           this.paste(enteredText.textToSend, enteredText.timeout);
         }
       });

--- a/src/app/components/options-bar/options-bar.component.ts
+++ b/src/app/components/options-bar/options-bar.component.ts
@@ -177,9 +177,10 @@ export class OptionsBarComponent implements OnInit, OnDestroy {
   sendInputString() {
     this.dialogService
       .sendText('Enter Text to Send')
-      .subscribe((enteredText) => {
-        if (enteredText) {
-          this.vmService.wmks.sendInputString(enteredText);
+      .subscribe((enteredText: any) => {
+        if (enteredText.textToSend) {
+          console.log(enteredText);
+          this.paste(enteredText.textToSend, enteredText.timeout);
         }
       });
   }
@@ -386,10 +387,20 @@ export class OptionsBarComponent implements OnInit, OnDestroy {
   async pasteFromClipboard() {
     try {
       const clip = await navigator.clipboard.readText();
-      this.vmService.wmks.sendInputString(clip);
+      await this.paste(clip);
+      
     } catch (err) {
       // If an error occur trying to read the local clipboard, simply open the input menu.
       this.sendInputString();
+    }
+  }
+
+  async paste(text: string, timeoutStr: string = "50") {
+    const timeout = parseInt(timeoutStr);
+    for (const line of text.split('\n')) {
+      this.vmService.wmks.sendInputString(line);
+      this.vmService.wmks.sendInputString('\n');
+      await new Promise(r => setTimeout(r, timeout));
     }
   }
 

--- a/src/app/components/shared/send-text-dialog/send-text-dialog.component.html
+++ b/src/app/components/shared/send-text-dialog/send-text-dialog.component.html
@@ -5,12 +5,52 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
 
 <form (ngSubmit)="send()" class="form-area">
   <div class="sendtext" fxLayout="column" fxLayoutAlign="space-around center">
+    <div class="topbar-container" fxFill fxLayout="row">
+      <button 
+        mat-icon-button
+        type="button"
+        class="mat-small"
+        [matMenuTriggerFor]="advancedTextMenu"
+        matTooltip="Advanced"
+        matTooltipPosition="after"
+        >
+        <mat-icon class="text" svgIcon="gear" alt="Gear"></mat-icon>
+      </button>
+    </div>
+    <mat-menu #advancedTextMenu="matMenu">
+      <button
+          type="button"
+          mat-menu-item
+          [matMenuTriggerFor]="pasteMenu"
+          matTooltipPosition="after"
+          aria-label="warning"
+        >
+          <span
+            [matTooltip]="
+              'Delay between sending each line. 
+               Go slower if paste errors are occurring'
+            "
+            matTooltipPosition="above"
+          >
+            Paste Speed
+          </span>
+        </button>
+        <mat-menu #pasteMenu="matMenu">
+          <button
+            type="button"
+            mat-menu-item
+            *ngFor="let pasteSpeed of settingsService.settings.PasteSpeeds"
+            (click)="setPasteSpeed(pasteSpeed.value)"
+          >
+            {{ pasteSpeed.name }}
+          </button>
+        </mat-menu>
+      </mat-menu>
     <h3>{{title}}</h3>
-      <textarea matInput class="text-area" matInput tabIndex="1" name="textToSend" [(ngModel)]="textToSend"></textarea>
+    <textarea matInput class="text-area" matInput tabIndex="1" name="textToSend" [(ngModel)]="textToSend"></textarea>
     <mat-dialog-actions style="padding-bottom: 25px;" fxFill fxLayout="row" fxLayoutAlign="space-around center">
       <button mat-stroked-button (click)="close()" tabIndex="2">Cancel</button>
       <button mat-stroked-button (click)="send()" tabindex="3">Send</button>
-    </mat-dialog-actions>  
+    </mat-dialog-actions>
   </div>
 </form>
-

--- a/src/app/components/shared/send-text-dialog/send-text-dialog.component.scss
+++ b/src/app/components/shared/send-text-dialog/send-text-dialog.component.scss
@@ -1,6 +1,12 @@
 // Copyright 2021 Carnegie Mellon University. All Rights Reserved.
 // Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
 
+.topbar-container {
+    width: 100%;
+    top: 0px;
+    left: 0px;
+    padding-bottom: 1px;
+  }
 
 .sendtext {
     width: 100%;
@@ -30,4 +36,17 @@
     resize: both;
 }
 
+.mat-icon-button.mat-small {
+    line-height: 16px;
+    height: 16px;
+    width: 16px;
+    margin-top: 2px;
+    margin-left: 10px;
+    display: inline-block;
+    z-index: 1;
+  }
 
+.mat-icon {
+    height: 18px;
+    width: 18px;
+  }

--- a/src/app/components/shared/send-text-dialog/send-text-dialog.component.ts
+++ b/src/app/components/shared/send-text-dialog/send-text-dialog.component.ts
@@ -3,6 +3,7 @@
 
 import { Component, Inject } from '@angular/core';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { ComnSettingsService } from '@cmusei/crucible-common';
 
 @Component({
   selector: 'send-text-dialog',
@@ -12,9 +13,11 @@ import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 export class SendTextDialogComponent {
   public title: string;
   public textToSend: string;
+  public pasteSpeed: string;
 
-  constructor(
-    @Inject(MAT_DIALOG_DATA) data,
+  constructor(    
+    @Inject(MAT_DIALOG_DATA) data,    
+    public settingsService: ComnSettingsService,
     private dialogRef: MatDialogRef<SendTextDialogComponent>
   ) {
     this.dialogRef.disableClose = true;
@@ -25,7 +28,14 @@ export class SendTextDialogComponent {
     this.dialogRef.close(undefined);
   }
 
+  setPasteSpeed(speed: string) {
+    this.pasteSpeed = speed;
+  }
+
   send() {
-    this.dialogRef.close(this.textToSend);
+    this.dialogRef.close({
+      textToSend: this.textToSend,
+      timeout: this.pasteSpeed
+    });
   }
 }

--- a/src/assets/config/settings.json
+++ b/src/assets/config/settings.json
@@ -25,5 +25,12 @@
     { "width": 1280, "height": 720 },
     { "width": 1024, "height": 768 },
     { "width": 800, "height": 600 }
+  ],
+  "PasteSpeeds": [
+    { "name": "Fastest", "value": 10 },
+    { "name": "Fast", "value": 30 },
+    { "name": "Normal", "value": 60 },
+    { "name": "Slow", "value": 100 },
+    { "name": "Slowest", "value": 500 }
   ]
 }


### PR DESCRIPTION
This feature follows in the footsteps of what [Topomojo](https://github.com/cmu-sei/topomojo-ui/blob/2bc045669852789d9f266d991819401d39481031/src/app/ui/core/console/services/wmks-console.service.ts#L96-L104) does to solve the issue of garbled pasting of large blocks of text.

Instead of just requiring a default number of milliseconds, it sets a default of `50ms` but also allows the user to select different speeds in an advanced menu for the text input, which are configurable in appsettings.

Addresses internal ticket `CRU-661`.